### PR TITLE
Fix inline styles

### DIFF
--- a/src/multi-selector.css
+++ b/src/multi-selector.css
@@ -107,7 +107,11 @@ cp-multi-selector-item.\+selected .cp-multi-selector-item__check {
 
 .cp-multi-selector__pill.\+inline {
 	position: relative;
-	top: 3px;
+	font-weight: normal;
+	height: 32px;
+	top: 0px;
+	border-radius: 2px;
+	padding: 6px 8px;
 }
 
 .cp-multi-selector__pill .cps-icon {


### PR DESCRIPTION
This pulls some common styling throughout the app into the cp-multi-selector library, essentially everywhere we have inline pills we need this styling and it was duplicated everywhere.
